### PR TITLE
Trash Managment Loop In History Import

### DIFF
--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -1018,9 +1018,10 @@ class Otis_Importer {
 	function _translate_taxonomy_value( $taxonomy, $value ) {
 		if ( $value ) {
 			if ( is_array( $value ) && isset( $value[0] ) ) {
-				return array_flatten( array_map( function ( $item ) use ( $taxonomy ) {
+				$tax_array = array_map( function ( $item ) use ( $taxonomy ) {
 					return $this->_translate_taxonomy_value( $taxonomy, $item );
-				}, $value ) );
+				}, $value );
+				return array_flatten( $tax_array );
 			}
 
 			$terms = null;

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -1021,7 +1021,7 @@ class Otis_Importer {
 				$tax_array = array_map( function ( $item ) use ( $taxonomy ) {
 					return $this->_translate_taxonomy_value( $taxonomy, $item );
 				}, $value );
-				return array_flatten( $tax_array );
+				return array_flatten( $tax_array, INF );
 			}
 
 			$terms = null;

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -552,6 +552,7 @@ class Otis_Importer {
 				}
 
 				foreach ($history_deletes as $post_id) {
+					$this->logger->log('Trashing post ' . $post_id);
 					wp_trash_post($post_id);
 				}
 
@@ -590,9 +591,7 @@ class Otis_Importer {
 	 */
     private function _fetch_history( $assoc_args = [], $transient_history = null ) {
 
-		$this->logger->log("Running _fetch_history with args " . print_r( $assoc_args, true ) );
-
-		$params = [
+        $params = [
             'page_size' => 500,
             'page'      => $assoc_args['history-page'] ?? 1,
         ];
@@ -642,9 +641,6 @@ class Otis_Importer {
             unset( $listings );
 
             if ( $params['page'] < $total ) {
-
-				$this->logger->log("_fetch_history ongoing. Returning and updating transient history data with " . count( $history) . " updates on history-page " . $params['page'] + 1 . "." );
-
                 set_transient(WP_OTIS_BULK_IMPORT_TRANSIENT,
 					[
 						"history-page" => $params['page'] + 1,
@@ -656,8 +652,6 @@ class Otis_Importer {
             }
 
         }
-
-		$this->logger->log("_fetch_history finished. Returning and updating transient history data with " . count( $history) . " updates." );
 
 		set_transient(WP_OTIS_BULK_IMPORT_TRANSIENT,
 			[
@@ -1028,7 +1022,7 @@ class Otis_Importer {
 				$tax_array = array_map( function ( $item ) use ( $taxonomy ) {
 					return $this->_translate_taxonomy_value( $taxonomy, $item );
 				}, $value );
-				return array_flatten( $tax_array, PHP_INT_MAX );
+				return array_flatten( $tax_array, INF );
 			}
 
 			$terms = null;

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -563,7 +563,7 @@ class Otis_Importer {
 						$assoc_args['bulk-history-page'] = $assoc_args['bulk-history-page'] + 1;
 						$this->logger->log('Enqueueing history import page ' . $assoc_args['bulk-history-page']);
 						as_enqueue_async_action('wp_otis_async_bulk_history_import', ['params' => ['all' => $assoc_args['all'], 'page' => $assoc_args['bulk-history-page'], 'bulk-history-page' => $assoc_args['bulk-history-page'], 'modified' => $assoc_args['modified'], 'related_only' => $assoc_args['related_only']]]);
-					} elseif ($assoc_args['bulk-history-page'] >= $history_page_count) {
+					} elseif ($assoc_args['bulk-history-page'] == $history_page_count) {
 						update_option(WP_OTIS_BULK_HISTORY_ACTIVE, false);
 						delete_transient(WP_OTIS_BULK_IMPORT_TRANSIENT);
 						as_unschedule_all_actions('wp_otis_async_bulk_history_import');

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -1022,7 +1022,7 @@ class Otis_Importer {
 				$tax_array = array_map( function ( $item ) use ( $taxonomy ) {
 					return $this->_translate_taxonomy_value( $taxonomy, $item );
 				}, $value );
-				return array_flatten( $tax_array, INF );
+				return array_flatten( $tax_array, PHP_INT_MAX );
 			}
 
 			$terms = null;

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -467,7 +467,6 @@ class Otis_Importer {
 		if (!$bulk) {
 			$this->logger->log("Running history import with arguments: ".print_r($assoc_args, true));
 			$transient_history = get_transient(WP_OTIS_BULK_IMPORT_TRANSIENT);
-			$this->logger->log("Transient history: ".print_r($transient_history, true));
 
 			if ( empty( $transient_history ) ) {
 				// If there is no data to process, go get it.
@@ -478,14 +477,6 @@ class Otis_Importer {
 				// If a retrieval process is ongoing, continue it.
 				$assoc_args['history-page'] = $transient_history['history-page'];
 				$this->_fetch_history($assoc_args, $transient_history['history-data']);
-			} elseif ( isset( $transient_history["history-complete"] )
-				&& $transient_history["history-complete"] ) {
-				// If a retrieval process is complete, unset everything.
-				update_option(WP_OTIS_BULK_HISTORY_ACTIVE, false);
-				delete_transient(WP_OTIS_BULK_IMPORT_TRANSIENT);
-				as_unschedule_all_actions('wp_otis_async_bulk_history_import');
-				$this->logger->log("OTIS nonbulk history import complete.");
-				return;
 			}
 
 			// This may have changed during the _fetch_history call, so retrieve it again.

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -551,6 +551,7 @@ class Otis_Importer {
 					}
 				}
 
+				// Run through the post ids in history_deletes and trash the posts.
 				foreach ($history_deletes as $post_id) {
 					$this->logger->log('Trashing post ' . $post_id);
 					wp_trash_post($post_id);
@@ -562,7 +563,7 @@ class Otis_Importer {
 					if ($assoc_args['bulk-history-page'] < $history_page_count) {
 						$assoc_args['bulk-history-page'] = $assoc_args['bulk-history-page'] + 1;
 						$this->logger->log('Enqueueing history import page ' . $assoc_args['bulk-history-page']);
-						as_enqueue_async_action('wp_otis_async_bulk_history_import', ['params' => ['all' => $assoc_args['all'], 'page' => $assoc_args['bulk-history-page'], 'bulk-history-page' => $assoc_args['bulk-history-page'], 'modified' => $assoc_args['modified'], 'related_only' => $assoc_args['related_only']]]);
+						as_enqueue_async_action('wp_otis_async_bulk_history_import', ['params' => ['all' => $assoc_args['all'], 'page' => $assoc_args['bulk-history-page'], 'modified' => $assoc_args['modified'], 'related_only' => $assoc_args['related_only']]]);
 					} elseif ($assoc_args['bulk-history-page'] == $history_page_count) {
 						update_option(WP_OTIS_BULK_HISTORY_ACTIVE, false);
 						delete_transient(WP_OTIS_BULK_IMPORT_TRANSIENT);

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -559,11 +559,11 @@ class Otis_Importer {
 				// Wrap up this job: either enqueue a follow-up and leave the transient and flags intact,
 				// or clear them and log the completed result.
 				if ($history_bulk) {
-					if ($assoc_args['bulk-history-page'] < $history_page_count) {
+					if ($assoc_args['bulk-history-page'] <= $history_page_count) {
 						$assoc_args['bulk-history-page'] = $assoc_args['bulk-history-page'] + 1;
 						$this->logger->log('Enqueueing history import page ' . $assoc_args['bulk-history-page']);
 						as_enqueue_async_action('wp_otis_async_bulk_history_import', ['params' => ['all' => $assoc_args['all'], 'page' => $assoc_args['bulk-history-page'], 'modified' => $assoc_args['modified'], 'related_only' => $assoc_args['related_only']]]);
-					} elseif ($assoc_args['bulk-history-page'] == $history_page_count) {
+					} elseif ($assoc_args['bulk-history-page'] > $history_page_count) {
 						update_option(WP_OTIS_BULK_HISTORY_ACTIVE, false);
 						delete_transient(WP_OTIS_BULK_IMPORT_TRANSIENT);
 						as_unschedule_all_actions('wp_otis_async_bulk_history_import');

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -464,11 +464,10 @@ class Otis_Importer {
 
 		$bulk = get_option( WP_OTIS_BULK_IMPORT_ACTIVE, false );
 
-		$this->logger->log( 'Bulk Import Status: '.$bulk );
-
 		if (!$bulk) {
 			$this->logger->log("Running history import with arguments: ".print_r($assoc_args, true));
 			$transient_history = get_transient(WP_OTIS_BULK_IMPORT_TRANSIENT);
+			$this->logger->log("Transient history: ".print_r($transient_history, true));
 
 			if ( empty( $transient_history ) ) {
 				// If there is no data to process, go get it.

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -563,7 +563,7 @@ class Otis_Importer {
 						$assoc_args['bulk-history-page'] = $assoc_args['bulk-history-page'] + 1;
 						$this->logger->log('Enqueueing history import page ' . $assoc_args['bulk-history-page']);
 						as_enqueue_async_action('wp_otis_async_bulk_history_import', ['params' => ['all' => $assoc_args['all'], 'page' => $assoc_args['bulk-history-page'], 'bulk-history-page' => $assoc_args['bulk-history-page'], 'modified' => $assoc_args['modified'], 'related_only' => $assoc_args['related_only']]]);
-					} elseif ($assoc_args['bulk-history-page'] == $history_page_count) {
+					} elseif ($assoc_args['bulk-history-page'] >= $history_page_count) {
 						update_option(WP_OTIS_BULK_HISTORY_ACTIVE, false);
 						delete_transient(WP_OTIS_BULK_IMPORT_TRANSIENT);
 						as_unschedule_all_actions('wp_otis_async_bulk_history_import');

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -1021,7 +1021,7 @@ class Otis_Importer {
 				$tax_array = array_map( function ( $item ) use ( $taxonomy ) {
 					return $this->_translate_taxonomy_value( $taxonomy, $item );
 				}, $value );
-				return array_flatten( $tax_array, INF );
+				return array_flatten( $tax_array, PHP_INT_MAX );
 			}
 
 			$terms = null;

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -464,6 +464,8 @@ class Otis_Importer {
 
 		$bulk = get_option( WP_OTIS_BULK_IMPORT_ACTIVE, false );
 
+		$this->logger->log( 'Bulk Import Status: '.$bulk );
+
 		if (!$bulk) {
 			$this->logger->log("Running history import with arguments: ".print_r($assoc_args, true));
 			$transient_history = get_transient(WP_OTIS_BULK_IMPORT_TRANSIENT);
@@ -572,6 +574,7 @@ class Otis_Importer {
 				} else {
 					update_option(WP_OTIS_BULK_HISTORY_ACTIVE, false);
 					delete_transient(WP_OTIS_BULK_IMPORT_TRANSIENT);
+					as_unschedule_all_actions('wp_otis_async_bulk_history_import');
 					$this->logger->log("OTIS nonbulk history import complete.");
 				}
 			}

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -478,6 +478,14 @@ class Otis_Importer {
 				// If a retrieval process is ongoing, continue it.
 				$assoc_args['history-page'] = $transient_history['history-page'];
 				$this->_fetch_history($assoc_args, $transient_history['history-data']);
+			} elseif ( isset( $transient_history["history-complete"] )
+				&& $transient_history["history-complete"] ) {
+				// If a retrieval process is complete, unset everything.
+				update_option(WP_OTIS_BULK_HISTORY_ACTIVE, false);
+				delete_transient(WP_OTIS_BULK_IMPORT_TRANSIENT);
+				as_unschedule_all_actions('wp_otis_async_bulk_history_import');
+				$this->logger->log("OTIS nonbulk history import complete.");
+				return;
 			}
 
 			// This may have changed during the _fetch_history call, so retrieve it again.

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -559,11 +559,11 @@ class Otis_Importer {
 				// Wrap up this job: either enqueue a follow-up and leave the transient and flags intact,
 				// or clear them and log the completed result.
 				if ($history_bulk) {
-					if ($assoc_args['bulk-history-page'] <= $history_page_count) {
+					if ($assoc_args['bulk-history-page'] < $history_page_count) {
 						$assoc_args['bulk-history-page'] = $assoc_args['bulk-history-page'] + 1;
 						$this->logger->log('Enqueueing history import page ' . $assoc_args['bulk-history-page']);
-						as_enqueue_async_action('wp_otis_async_bulk_history_import', ['params' => ['all' => $assoc_args['all'], 'page' => $assoc_args['bulk-history-page'], 'modified' => $assoc_args['modified'], 'related_only' => $assoc_args['related_only']]]);
-					} elseif ($assoc_args['bulk-history-page'] > $history_page_count) {
+						as_enqueue_async_action('wp_otis_async_bulk_history_import', ['params' => ['all' => $assoc_args['all'], 'page' => $assoc_args['bulk-history-page'], 'bulk-history-page' => $assoc_args['bulk-history-page'], 'modified' => $assoc_args['modified'], 'related_only' => $assoc_args['related_only']]]);
+					} elseif ($assoc_args['bulk-history-page'] == $history_page_count) {
 						update_option(WP_OTIS_BULK_HISTORY_ACTIVE, false);
 						delete_transient(WP_OTIS_BULK_IMPORT_TRANSIENT);
 						as_unschedule_all_actions('wp_otis_async_bulk_history_import');

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -590,7 +590,9 @@ class Otis_Importer {
 	 */
     private function _fetch_history( $assoc_args = [], $transient_history = null ) {
 
-        $params = [
+		$this->logger->log("Running _fetch_history with args " . print_r( $assoc_args, true ) );
+
+		$params = [
             'page_size' => 500,
             'page'      => $assoc_args['history-page'] ?? 1,
         ];
@@ -640,6 +642,9 @@ class Otis_Importer {
             unset( $listings );
 
             if ( $params['page'] < $total ) {
+
+				$this->logger->log("_fetch_history ongoing. Returning and updating transient history data with " . count( $history) . " updates on history-page " . $params['page'] + 1 . "." );
+
                 set_transient(WP_OTIS_BULK_IMPORT_TRANSIENT,
 					[
 						"history-page" => $params['page'] + 1,
@@ -651,6 +656,8 @@ class Otis_Importer {
             }
 
         }
+
+		$this->logger->log("_fetch_history finished. Returning and updating transient history data with " . count( $history) . " updates." );
 
 		set_transient(WP_OTIS_BULK_IMPORT_TRANSIENT,
 			[

--- a/wp-otis.php
+++ b/wp-otis.php
@@ -428,21 +428,34 @@ if ( ! function_exists('array_pluck'))
 /**
  * Laravel helper
  */
-if ( ! function_exists('array_flatten'))
-{
+if ( ! function_exists('array_flatten') ) {
 	/**
 	 * Flatten a multi-dimensional array into a single level.
 	 *
-	 * @param  array  $array
+	 * @param  iterable  $array
+	 * @param  int  $depth
+	 *
 	 * @return array
 	 */
-	function array_flatten($array)
+	function array_flatten(iterable $array, int $depth): array
 	{
-		$return = array();
+			$result = [];
 
-		array_walk_recursive($array, function($x) use (&$return) { $return[] = $x; });
+			foreach ($array as $item) {
+					if (!is_array($item)) {
+							$result[] = $item;
+					} else {
+							$values = $depth === 1
+									? array_values($item)
+									: array_flatten($item, $depth - 1);
 
-		return $return;
+							foreach ($values as $value) {
+									$result[] = $value;
+							}
+					}
+			}
+
+			return $result;
 	}
 }
 


### PR DESCRIPTION
## Overview
This adds an array to populate with post ids that have the verb `delete` during the `_import_history` function on 496 of Otis_Importer. This is then looped over after the updates are made to relevant posts and trashes the deleted posts.

## Testing
- [x] Apply this PR to a testing environment
- [x] Wait for a history import to run
- [x] Check that deleted POIs have been deleted in WP