### PR TITLE
Date range imports

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -49,6 +49,9 @@
 .otis-dashboard .otis-dashboard__settings .postbox.success {
 	background-color: #28834c;
 }
+.otis-dashboard .vdpr-datepicker__calendar-input-wrapper {
+	display: none;
+}
 .otis-dashboard .otis-dashboard__settings {
 	padding: 10px 0px;
 }

--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -1,3 +1,4 @@
+@import url("https://cdn.jsdelivr.net/npm/vue2-daterange-picker@0.6.7/dist/vue2-daterange-picker.min.css");
 .otis-dashboard {
 	padding-right: 10px;
 }

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -280,6 +280,7 @@
 				this.importStarting = true;
 				const importData = {from_date: this.dateRange.from, to_date: this.dateRange.to};
 				if (this.onlyImportHistory) importData.only_history = true;
+				console.log(importData);
 				await this.triggerAction('otis_import', importData);
 				await this.otisStatus();
 				this.notifyImportStarted();

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -80,6 +80,7 @@
 									:readonly="importStarting"
 									@date-applied="setDateRange"
 								/>
+								<label for="history-only"><input type="checkbox" name="history-only" id="history-only" v-model="onlyImportHistory"/>Only import history, do not import new POIs.</label>
                 <p v-if="importStarting">POI import starting, please wait this usually takes a few minutes...</p>
                 <button class="button button-primary" :disabled="!dateIsValid || importStarting || bulkImportActive || bulkImportScheduled" @click="triggerModifiedImport">
                   <span v-if="importStarting">
@@ -154,6 +155,7 @@
 				from: '',
 				to: '',
 			},
+			onlyImportHistory: false,
 			lastImportDate: "",
 			bulkImportActive: "",
 			bulkImportScheduled: false,
@@ -276,7 +278,9 @@
 			async triggerModifiedImport() {
 				if (!this.dateIsValid) return;
 				this.importStarting = true;
-				await this.triggerAction('otis_import', {from_date: this.dateRange.from, to_date: this.dateRange.to});
+				const importData = {from_date: this.dateRange.from, to_date: this.dateRange.to};
+				if (this.onlyImportHistory) importData.only_history = true;
+				await this.triggerAction('otis_import', importData);
 				await this.otisStatus();
 				this.notifyImportStarted();
 				this.importStarting = false;

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1,6 +1,9 @@
 (function () {
 	new Vue({
 		el: document.getElementById("otis-dashboard-mount"),
+		components: {
+			DateRangePicker
+		},
 		template: `
       <div class="otis-dashboard">
         <h1>OTIS Dashboard</h1>

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -2,7 +2,8 @@
 	new Vue({
 		el: document.getElementById("otis-dashboard-mount"),
 		components: {
-			DateRangePicker
+			'datepicker' : vdprDatePicker.default,
+			'calendar-dialog' : vdprDatePicker.CalendarDialog
 		},
 		template: `
       <div class="otis-dashboard">

--- a/src/Otis.php
+++ b/src/Otis.php
@@ -84,7 +84,7 @@ class Otis {
 	 * @return array
 	 * @throws \Otis_Exception
 	 */
-	public function call( $path, $params = array(), $logger = null ) {
+	public function call( $path, $params = array(), $logger = null, $verbose = false ) {
 		if ( $path && substr( $path, - 1 ) !== '/' ) {
 			$path .= '/';
 		}
@@ -102,8 +102,9 @@ class Otis {
 			return $this->_fetch( self::API_ROOT . '/' . $path, array(
 				'headers' => $headers,
 				'get'     => $params,
-			), $logger );
+			), $logger, $verbose );
 		} catch ( Otis_Exception $exception ) {
+			$logger->log('Otis Exception: ' . $exception->getCode() . ' - ' . $exception->getMessage());
 			if ( 401 === $exception->getCode() ) {
 				// Try fetching a new token if auth failed.
 				$token = $this->token( true );
@@ -125,7 +126,7 @@ class Otis {
 	 * @return array
 	 * @throws \Otis_Exception
 	 */
-	private function _fetch( $url, $options = array(), $logger = null) {
+	private function _fetch( $url, $options = array(), $logger = null, $verbose = false ) {
 		if ( ! empty( $options['get'] ) ) {
 			$url .= '?' . http_build_query( $options['get'] );
 		}
@@ -138,11 +139,11 @@ class Otis {
 		curl_setopt( $this->ch, CURLOPT_HTTPHEADER, $options['headers'] ?? array() );
 		curl_setopt( $this->ch, CURLOPT_TIMEOUT, 30 );
 
-		if ($logger) {
+		if ($logger && $verbose) {
 			$logger->log("About to curl_exec url ".$url);
 		}
 		$response_body = curl_exec( $this->ch );
-		if ($logger) {
+		if ($logger && $verbose) {
 			$logger->log("Call returned with options".json_encode($options));
 		}
 
@@ -162,7 +163,7 @@ class Otis {
 		}
 
 
-		if ($logger) {
+		if ($logger && $verbose) {
 			$logger->log("Returning from call with options".json_encode($options));
 		}
 		return json_decode( $response_body, true );

--- a/src/Otis_Dashboard.php
+++ b/src/Otis_Dashboard.php
@@ -44,14 +44,14 @@ class Otis_Dashboard
   }
 
   // calculate page_size based on import date
-  public function otis_calculate_page_size($modified_date) {
+  public function otis_calculate_page_size($modified_start_date, $modified_end_date) {
     $page_size = 25;
-    if ( ! $modified_date ) {
+    if ( ! $modified_start_date ) {
       return $page_size;
     }
-    $date = new DateTime( $modified_date );
-    $today = new DateTime( 'now' );
-    $diff = $date->diff( $today );
+    $start_date = new DateTime( $modified_start_date );
+    $end_date = new DateTime( $modified_end_date );
+    $diff = $start_date->diff( $end_date );
     if ( $diff->days > 30 ) {
       $page_size = 10;
     }
@@ -59,19 +59,23 @@ class Otis_Dashboard
   }
 
   public function otis_init_import() {
-    $modified = isset($_POST['modified_date']) ? _sanitize_text_fields($_POST['modified_date']) : false;
+    $modified_start = isset($_POST['from_date']) ? _sanitize_text_fields($_POST['from_date']) : false;
+    $modified_end = isset($_POST['to_date']) ? _sanitize_text_fields($_POST['to_date']) : false;
     $initial = isset($_POST['initial_import']);
     $args = array();
     $assoc_args = array(
-      'page_size' => $this->otis_calculate_page_size($modified),
+      'page_size' => $this->otis_calculate_page_size($modified_start, $modified_end),
     );
     if ($initial) {
       $args[0] = 'pois';
     } else {
       $args[0] = 'pois-only';
     }
-    if ($modified) {
-      $assoc_args['modified'] = $modified;
+    if ($modified_start && $modified_end) {
+      $assoc_args['modified_start'] = $modified_start;
+      $assoc_args['modified_end'] = $modified_end;
+    } else {
+      $assoc_args['modified'] = $modified_start;
     }
     try {
       as_enqueue_async_action( 'wp_otis_dashboard_start_async_import', ['args' => $args, 'assoc_args' => $assoc_args] );

--- a/src/Otis_Dashboard.php
+++ b/src/Otis_Dashboard.php
@@ -11,9 +11,11 @@ class Otis_Dashboard
   public function otis_dashboard_scripts() {
     wp_enqueue_media();
     wp_register_script( 'axios', 'https://cdnjs.cloudflare.com/ajax/libs/axios/0.21.1/axios.min.js', [], '0.21.1' );
-    wp_register_script( 'vue-date-range', 'https://cdn.jsdelivr.net/npm/vue2-daterange-picker@0.6.7/dist/vue2-daterange-picker.umd.min.js', [], '0.6.7' );
+    wp_register_script( 'vue-moment', 'https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.27.0/moment-with-locales.min.js', [], '2.27.0' );
+    wp_register_script( 'vue-date-range', 'https://unpkg.com/vue-time-date-range-picker@1.5.0/dist/vdprDatePicker.js', [], '1.5.0' );
     wp_register_script( 'vue', 'https://cdn.jsdelivr.net/npm/vue@2.6.14', [], '2.6.14' );
     wp_enqueue_script( 'axios' );
+    wp_enqueue_script( 'vue-moment' );
     wp_enqueue_script( 'vue-date-range' );
     wp_enqueue_script( 'vue' );
     wp_register_script( 'otis-dashboard', plugins_url( '../js/dashboard.js', __FILE__ ), [], '1.0', true );

--- a/src/Otis_Dashboard.php
+++ b/src/Otis_Dashboard.php
@@ -14,6 +14,7 @@ class Otis_Dashboard
     wp_register_script( 'vue-date-range', 'https://cdn.jsdelivr.net/npm/vue2-daterange-picker@0.6.7/dist/vue2-daterange-picker.umd.min.js', [], '0.6.7' );
     wp_register_script( 'vue', 'https://cdn.jsdelivr.net/npm/vue@2.6.14', [], '2.6.14' );
     wp_enqueue_script( 'axios' );
+    wp_enqueue_script( 'vue-date-range' );
     wp_enqueue_script( 'vue' );
     wp_register_script( 'otis-dashboard', plugins_url( '../js/dashboard.js', __FILE__ ), [], '1.0', true );
     wp_localize_script( 'otis-dashboard', 'otisDash', array( 'ajax_url' => admin_url( 'admin-ajax.php' ), 'admin_url' => admin_url() ) );

--- a/src/Otis_Dashboard.php
+++ b/src/Otis_Dashboard.php
@@ -62,12 +62,15 @@ class Otis_Dashboard
     $modified_start = isset($_POST['from_date']) ? _sanitize_text_fields($_POST['from_date']) : false;
     $modified_end = isset($_POST['to_date']) ? _sanitize_text_fields($_POST['to_date']) : false;
     $initial = isset($_POST['initial_import']);
+    $history_only = isset($_POST['history_only']);
     $args = array();
     $assoc_args = array(
       'page_size' => $this->otis_calculate_page_size($modified_start, $modified_end),
     );
     if ($initial) {
       $args[0] = 'pois';
+    } else if ($history_only) {
+      $args[0] = 'history-only';
     } else {
       $args[0] = 'pois-only';
     }

--- a/src/Otis_Dashboard.php
+++ b/src/Otis_Dashboard.php
@@ -11,6 +11,7 @@ class Otis_Dashboard
   public function otis_dashboard_scripts() {
     wp_enqueue_media();
     wp_register_script( 'axios', 'https://cdnjs.cloudflare.com/ajax/libs/axios/0.21.1/axios.min.js', [], '0.21.1' );
+    wp_register_script( 'vue-date-range', 'https://cdn.jsdelivr.net/npm/vue2-daterange-picker@0.6.7/dist/vue2-daterange-picker.umd.min.js', [], '0.6.7' );
     wp_register_script( 'vue', 'https://cdn.jsdelivr.net/npm/vue@2.6.14', [], '2.6.14' );
     wp_enqueue_script( 'axios' );
     wp_enqueue_script( 'vue' );

--- a/src/Otis_Dashboard.php
+++ b/src/Otis_Dashboard.php
@@ -62,7 +62,7 @@ class Otis_Dashboard
     $modified_start = isset($_POST['from_date']) ? _sanitize_text_fields($_POST['from_date']) : false;
     $modified_end = isset($_POST['to_date']) ? _sanitize_text_fields($_POST['to_date']) : false;
     $initial = isset($_POST['initial_import']);
-    $history_only = isset($_POST['history_only']);
+    $history_only = isset($_POST['only_history']);
     $args = array();
     $assoc_args = array(
       'page_size' => $this->otis_calculate_page_size($modified_start, $modified_end),

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -325,7 +325,6 @@ class Otis_Importer {
 				$modified_datestamp = strtotime( $modified_datetime );
 				$start_datestamp = strtotime( $start_date );
 				$end_datestamp = strtotime( $end_date );
-				$this->logger->log('Result modified date: ' . $modified_datestamp . ' w/ start: ' . $start_datestamp . ' and end: ' . $end_datestamp);
 
 				if ( $modified_datestamp >= $start_datestamp && $modified_datestamp <= $end_datestamp ) {
 					$filtered_results[] = $result;
@@ -390,13 +389,14 @@ class Otis_Importer {
 
 				if ( isset( $params['start_date']) && isset( $params['end_date'] ) ) {
 					// filter listings by modified date
-					$this->logger->log('Filtering OTIS ' . $listings['count'] . ' results by modified param using args: ' . print_r( $params, true ) );
+					$this->logger->log('Filtering ' . $listings['count'] . ' OTIS results by modified param using dates: ' . $params['start_date'] . ' - ' . $params['end_date'] );
 					$filtered_results = $this->_filter_results_by_date( $listings['results'], $params );
 					$listings['results'] = $filtered_results;
 					$this->logger->log(count($listings['results']) . ' relevant results');
 				}
 
         if ( empty( $listings['results'] ) ) {
+						$this->logger->log('No relevant results continuing to next set...');
             return;
         }
 

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -570,7 +570,6 @@ class Otis_Importer {
 			// Did the most recent fetch job finish filling out the retrieved history data?
 			if ( !$transient_history["history-complete"] ) {
 				// If not, enqueue a follow-up.
-				$this->logger->log('Continuing to fetch history data...');
 				$bulk_history_params = [
 					'params' => [
 						'all' => $assoc_args['all'],

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -414,6 +414,7 @@ class Otis_Importer {
             }
 
             try {
+							$this->logger->log("Upserting post " . $post_id); 
 							$post_id = $this->_upsert_poi( $post_id, $result, $import_related_only );
             } catch ( Exception $exception ) {
 							$this->logger->log( $exception->getMessage(), $post_id, 'error' );
@@ -877,8 +878,10 @@ class Otis_Importer {
             ], true);
 
             if (!$post_result) {
+								$this->logger->log('Error: POI not ' . $upsert_status . ', uuid ' . $result['uuid']);
                 throw new Otis_Exception('Error: POI not ' . $upsert_status . ', uuid ' . $result['uuid']);
             } elseif (is_wp_error($post_result)) {
+								$this->logger->log('Error: POI not ' . $upsert_status . ', uuid ' . $result['uuid']);
                 throw new Otis_Exception('Error: POI not ' . $upsert_status . ', uuid ' . $result['uuid'] . ', ' . $post_result->get_error_message());
             } else {
                 $post_id = $post_result;
@@ -889,6 +892,7 @@ class Otis_Importer {
                     $return = update_field($name, $data[$name], $post_id);
 
                     if (is_wp_error($return)) {
+												$this->logger->log('Error: field ' . $name . ', post id ' . $post_id . ', ' . $return->get_error_message());
                         throw new Otis_Exception('Error: field ' . $name . ', post id ' . $post_id . ', ' . $return->get_error_message());
                     }
                 }
@@ -905,6 +909,7 @@ class Otis_Importer {
             $return = wp_set_object_terms($post_id, $data['type'], 'type');
 
             if (is_wp_error($return)) {
+								$this->logger->log('Error: taxonomy type, post id ' . $post_id . ', ' . $return->get_error_message());
                 throw new Otis_Exception('Error: taxonomy type, post id ' . $post_id . ', ' . $return->get_error_message());
             }
 
@@ -912,6 +917,7 @@ class Otis_Importer {
             $return = wp_set_object_terms($post_id, $data['glocats'], 'glocats');
 
             if (is_wp_error($return)) {
+								$this->logger->log('Error: taxonomy glocats, post id ' . $post_id . ', ' . $return->get_error_message());
                 throw new Otis_Exception('Error: taxonomy glocats, post id ' . $post_id . ', ' . $return->get_error_message());
             }
 

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -338,14 +338,17 @@ class Otis_Importer {
             $params['modified'] = date( 'Y-m-d\TH:i:s\Z', strtotime( $assoc_args['modified'] ) );
 				// Check if we're doing a modified_start date without an end date. If so fallback to basic modified date param.
         } else if ( isset( $assoc_args['modified_start'] ) && ! isset( $assoc_args['modified_end'] ) ) {
+						$assoc_args['all']  = true;
 						$params['modified'] = date( 'Y-m-d\TH:i:s\Z', strtotime( $assoc_args['modified_start'] ) );
 				// Check if we're both modified start and end dates are present.
 				} else if ( isset( $assoc_args['modified_start'] ) && isset( $assoc_args['modified_end'] ) ) {
 						// If both modified dates are present check if they're the equal. If so fallback to basic modified date param.
 						if ( $assoc_args['modified_start'] === $assoc_args['modified_end'] ) {
+								$assoc_args['all']  = true;
 								$params['modified'] = date( 'Y-m-d\TH:i:s\Z', strtotime( $assoc_args['modified_start'] ) );
 						// If they're different use the after & before parameters
 						} else {
+								$assoc_args['all']  = true;
 								$params['after'] = date( 'Y-m-d\TH:i:s\Z', strtotime( $assoc_args['modified_start'] ) );
 								$params['before']   = date( 'Y-m-d\TH:i:s\Z', strtotime( $assoc_args['modified_end'] ) );
 						}
@@ -372,7 +375,7 @@ class Otis_Importer {
         /* First page of an import that will require multiple chapters */
         if ((($listings['count'] / $params['page_size']) > $chapter_size) && ($params['page'] == 1)) {
             update_option( WP_OTIS_BULK_IMPORT_ACTIVE, true );
-						$logger_date = isset($assoc_args['modified']) ? "(".date( 'Y-m-d', strtotime( $assoc_args['modified'] ) ).")" : "";
+						$logger_date = $this->_get_logger_modified_date_string($assoc_args);
 						$this->logger->log("OTIS bulk import detected: ".$listings['count']." updates. ".$logger_date);
         }
 

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -523,7 +523,26 @@ class Otis_Importer {
 			// Did the most recent fetch job finish filling out the retrieved history data?
 			if ( !$transient_history["history-complete"] ) {
 				// If not, enqueue a follow-up.
-				as_enqueue_async_action('wp_otis_async_bulk_history_import', ['params' => ['all' => $assoc_args['all'], 'page' => 1, 'modified' => $assoc_args['modified'], 'related_only' => $assoc_args['related_only']]]);
+				$bulk_history_params = [
+					'params' => [
+						'all' => $assoc_args['all'],
+						'page' => 1,
+						'related_only' => $assoc_args['related_only']
+					]
+				];
+				if ( isset( $assoc_args['modified_start'] ) && isset( $assoc_args['modified_end'] ) ) {
+					// If both modified dates are present check if they're the equal. If so fallback to basic modified date param.
+					if ( $assoc_args['modified_start'] === $assoc_args['modified_end'] ) {
+						$bulk_history_params['params']['modified'] = $assoc_args['modified'];
+					// If they're different use the start & end dates.
+					} else {
+						$bulk_history_params['params']['modified_start'] = $assoc_args['modified_start'];
+						$bulk_history_params['params']['modified_end'] = $assoc_args['modified_end'];
+					}
+				} else {
+					$bulk_history_params['params']['modified'] = $assoc_args['modified'];
+				}
+				as_enqueue_async_action('wp_otis_async_bulk_history_import', $bulk_history_params);
 			} else {
 				// If retrieval is complete, get the data from the transient.
 				$history 			      = $transient_history["history-data"];

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -723,8 +723,10 @@ class Otis_Importer {
             return [];
         }
 
-				$this->logger->log('Calling to OTIS w/ params: ' . print_r( $params, true ) );
         $listings = $this->otis->call( 'listings/history', $params );
+				$total = ceil( $listings['count'] / $params['page_size'] );
+
+				$this->logger->log('Pre-fetching page ' . $params['page'] . ' of ' . $total . ' of ' . $listings['count'] . ' history items');
 
         $history = !empty($transient_history) ? $transient_history : [];
 
@@ -755,8 +757,6 @@ class Otis_Importer {
 
                 }
             }
-
-            $total = ceil( $listings['count'] / $params['page_size'] );
 
             unset( $listings );
 

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -322,6 +322,7 @@ class Otis_Importer {
 
 			foreach ( $results as $result ) {
 				$modified_datetime = $result['modified'];
+				$this->logger->log('Result modified date: ' . $modified_datetime );
 				$modified_datetime = strtotime( $modified_datetime );
 
 				if ( $modified_datetime >= $start_date && $modified_datetime <= $end_date ) {
@@ -387,10 +388,10 @@ class Otis_Importer {
 
 				if ( isset( $params['start_date']) && isset( $params['end_date'] ) ) {
 					// filter listings by modified date
-					$this->logger->log('Filtering OTIS ' . $listings['count'] . 'results by modified param using args: ' . print_r( $params, true ) );
+					$this->logger->log('Filtering OTIS ' . $listings['count'] . ' results by modified param using args: ' . print_r( $params, true ) );
 					$filtered_results = $this->_filter_results_by_date( $listings['results'], $params );
 					$listings['results'] = $filtered_results;
-					$this->logger->log(count($listings['results']) . 'relevant results');
+					$this->logger->log(count($listings['results']) . ' relevant results');
 				}
 
         if ( empty( $listings['results'] ) ) {

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -570,6 +570,7 @@ class Otis_Importer {
 			// Did the most recent fetch job finish filling out the retrieved history data?
 			if ( !$transient_history["history-complete"] ) {
 				// If not, enqueue a follow-up.
+				$this->logger->log('Continuing to fetch history data...');
 				$bulk_history_params = [
 					'params' => [
 						'all' => $assoc_args['all'],
@@ -723,6 +724,7 @@ class Otis_Importer {
             return [];
         }
 
+				$this->logger->log('Calling to OTIS w/ params: ' . print_r( $params, true ) );
         $listings = $this->otis->call( 'listings/history', $params );
 
         $history = !empty($transient_history) ? $transient_history : [];

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -389,14 +389,14 @@ class Otis_Importer {
 
 				if ( isset( $params['start_date']) && isset( $params['end_date'] ) ) {
 					// filter listings by modified date
-					$this->logger->log('Filtering ' . $listings['count'] . ' OTIS results by modified param using dates: ' . $params['start_date'] . ' - ' . $params['end_date'] );
+					$this->logger->log('Filtering this page of OTIS results by modified param using dates: ' . $params['start_date'] . ' - ' . $params['end_date'] );
 					$filtered_results = $this->_filter_results_by_date( $listings['results'], $params );
 					$listings['results'] = $filtered_results;
 					$this->logger->log(count($listings['results']) . ' relevant results');
 				}
 
         if ( empty( $listings['results'] ) ) {
-						$this->logger->log('No relevant results continuing to next set...');
+						$this->logger->log('No relevant results continuing...');
             return;
         }
 

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -1016,10 +1016,7 @@ class Otis_Importer {
                 throw new Otis_Exception('Error: taxonomy glocats, post id ' . $post_id . ', ' . $return->get_error_message());
             }
 
-            $bulking = get_option(WP_OTIS_BULK_IMPORT_ACTIVE, false);
-            if (!$bulking) {
-                $this->logger->log(ucfirst($upsert_status) . ' POI with UUID: ' . $result['uuid'], $post_id);
-            }
+            $this->logger->log(ucfirst($upsert_status) . ' POI with UUID: ' . $result['uuid'], $post_id);
 
             return $post_id;
         }

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -322,10 +322,12 @@ class Otis_Importer {
 
 			foreach ( $results as $result ) {
 				$modified_datetime = $result['modified'];
-				$this->logger->log('Result modified date: ' . $modified_datetime );
-				$modified_datetime = strtotime( $modified_datetime );
+				$modified_datestamp = strtotime( $modified_datetime );
+				$start_datestamp = strtotime( $start_date );
+				$end_datestamp = strtotime( $end_date );
+				$this->logger->log('Result modified date: ' . $modified_datestamp . ' w/ start: ' . $start_datestamp . ' and end: ' . $end_datestamp);
 
-				if ( $modified_datetime >= $start_date && $modified_datetime <= $end_date ) {
+				if ( $modified_datestamp >= $start_datestamp && $modified_datestamp <= $end_datestamp ) {
 					$filtered_results[] = $result;
 				}
 			}

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -387,8 +387,10 @@ class Otis_Importer {
 
 				if ( isset( $params['start_date']) && isset( $params['end_date'] ) ) {
 					// filter listings by modified date
+					$this->logger->log('Filtering OTIS ' . $listings['count'] . 'results by modified param using args: ' . print_r( $params, true ) );
 					$filtered_results = $this->_filter_results_by_date( $listings['results'], $params );
 					$listings['results'] = $filtered_results;
+					$this->logger->log(count($listings['results']) . 'relevant results');
 				}
 
         if ( empty( $listings['results'] ) ) {

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -362,21 +362,21 @@ class Otis_Importer {
 
         if ( isset( $assoc_args['modified'] ) ) {
             $assoc_args['all']  = true;
-            $params['modified'] = date( 'mm/dd/yyyy', strtotime( $assoc_args['modified'] ) );
+            $params['modified'] = date( 'm/d/Y', strtotime( $assoc_args['modified'] ) );
 				// Check if we're doing a modified_start date without an end date. If so fallback to basic modified date param.
         } else if ( isset( $assoc_args['modified_start'] ) && ! isset( $assoc_args['modified_end'] ) ) {
 						$assoc_args['all']  = true;
-						$params['modified'] = date( 'mm/dd/yyyy', strtotime( $assoc_args['modified_start'] ) );
+						$params['modified'] = date( 'm/d/Y', strtotime( $assoc_args['modified_start'] ) );
 				// Check if we're both modified start and end dates are present.
 				} else if ( isset( $assoc_args['modified_start'] ) && isset( $assoc_args['modified_end'] ) ) {
 						// If both modified dates are present check if they're the equal. If so fallback to basic modified date param.
 						if ( $assoc_args['modified_start'] === $assoc_args['modified_end'] ) {
 								$assoc_args['all']   = true;
-								$params['modified'] = date( 'mm/dd/yyyy', strtotime( $assoc_args['modified_start'] ) );
+								$params['modified'] = date( 'm/d/Y', strtotime( $assoc_args['modified_start'] ) );
 						// If they're different use the after & before parameters
 						} else {
 								$assoc_args['all']   = true;
-								$params['modified']  = date( 'mm/dd/yyyy', strtotime( $assoc_args['modified_start'] ) );
+								$params['modified']  = date( 'm/d/Y', strtotime( $assoc_args['modified_start'] ) );
 								$params['start_date'] = $assoc_args['modified_start'];
 								$params['end_date']   = $assoc_args['modified_end'];
 						}

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -354,7 +354,7 @@ class Otis_Importer {
 						}
 				}
 
-				$this->logger->log('Calling OTIS listings w/ params', $params);
+				$this->logger->log('Calling OTIS listings w/ params' . $params);
         $listings = $this->otis->call( 'listings', $params );
 
         if ( empty( $listings['results'] ) ) {

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -435,7 +435,7 @@ class Otis_Importer {
 						$this->logger->log("Importing POIs with relationships only");
 					}
 
-					$uuids = array_pluck( $listings['results'], 'uuid' );
+					// $uuids = array_pluck( $listings['results'], 'uuid' );
 
 					/* First page of an import that will require multiple chapters */
 					if ((($listings['count'] / $params['page_size']) > $chapter_size) && ($params['page'] == 1)) {
@@ -444,47 +444,77 @@ class Otis_Importer {
 							$this->logger->log("OTIS bulk import detected: ".$listings['count']." updates. ".$logger_date);
 					}
 
-					$the_query = new WP_Query( [
-							'no_found_rows'          => true,
-							'update_post_meta_cache' => false,
-							'update_post_term_cache' => false,
-							'posts_per_page'         => - 1,
-							'post_status'            => 'any',
-							'post_type'              => 'poi',
-							'meta_key'               => 'uuid',
-							'meta_value'             => $uuids,
-					] );
-
-					$uuid_map = [];
-
-					while ( $the_query->have_posts() ) {
-							$the_query->the_post();
-
-							$uuid_map[ get_field( 'uuid' ) ] = get_the_ID();
-					}
-
-					wp_reset_postdata();
-
 					foreach ( $listings['results'] as $result ) {
-							$uuid    = $result['uuid'];
-							$post_id = $uuid_map[ $uuid ] ?? 0;
+						$uuid = $result['uuid'];
+						$this->logger->log("Processing POI with UUID: " . $uuid);
+						$poi_post = get_posts([
+							'post_type' => 'poi',
+							'post_status' => 'any',
+							'meta_key' => 'uuid',
+							'meta_value' => $uuid,
+							'posts_per_page' => - 1,
+						]);
+						$post_id = 0;
+						if (count($poi_post) > 0) {
+							$post_id = $poi_post[0]->ID;
+						}
+						$type = strtolower( $result['type']['name'] );
+						if ( 'regions' === $type || 'cities' === $type ) {
+								if ( ! isset( $assoc_args['type'] ) ) {
+										// Regions and cities have already been populated...
+										// Skip those when populating the rest of the listing results.
+										continue;
+								}
+						}
 
-							$type = strtolower( $result['type']['name'] );
-							if ( 'regions' === $type || 'cities' === $type ) {
-									if ( ! isset( $assoc_args['type'] ) ) {
-											// Regions and cities have already been populated...
-											// Skip those when populating the rest of the listing results.
-											continue;
-									}
-							}
-
-							try {
-								$post_id = $this->_upsert_poi( $post_id, $result, $import_related_only );
-							} catch ( Exception $exception ) {
-								$this->logger->log( $exception->getMessage(), $post_id, 'error' );
-							}
-
+						try {
+							$post_id = $this->_upsert_poi( $post_id, $result, $import_related_only );
+						} catch ( Exception $exception ) {
+							$this->logger->log( $exception->getMessage(), $post_id, 'error' );
+						}
 					}
+
+					// $the_query = new WP_Query( [
+					// 		'no_found_rows'          => true,
+					// 		'update_post_meta_cache' => false,
+					// 		'update_post_term_cache' => false,
+					// 		'posts_per_page'         => - 1,
+					// 		'post_status'            => 'any',
+					// 		'post_type'              => 'poi',
+					// 		'meta_key'               => 'uuid',
+					// 		'meta_value'             => $uuids,
+					// ] );
+
+					// $uuid_map = [];
+
+					// while ( $the_query->have_posts() ) {
+					// 		$the_query->the_post();
+
+					// 		$uuid_map[ get_field( 'uuid' ) ] = get_the_ID();
+					// }
+
+					// wp_reset_postdata();
+
+					// foreach ( $listings['results'] as $result ) {
+					// 		$uuid    = $result['uuid'];
+					// 		$post_id = $uuid_map[ $uuid ] ?? 0;
+
+					// 		$type = strtolower( $result['type']['name'] );
+					// 		if ( 'regions' === $type || 'cities' === $type ) {
+					// 				if ( ! isset( $assoc_args['type'] ) ) {
+					// 						// Regions and cities have already been populated...
+					// 						// Skip those when populating the rest of the listing results.
+					// 						continue;
+					// 				}
+					// 		}
+
+					// 		try {
+					// 			$post_id = $this->_upsert_poi( $post_id, $result, $import_related_only );
+					// 		} catch ( Exception $exception ) {
+					// 			$this->logger->log( $exception->getMessage(), $post_id, 'error' );
+					// 		}
+
+					// }
 
 					$total = ceil( $listings['count'] / $params['page_size'] );
 

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -382,7 +382,8 @@ class Otis_Importer {
 						}
 				}
 
-        $listings = $this->otis->call( 'listings', $params, $this->logger );
+        $this->logger->log('Calling to OTIS w/ params: ' . print_r( $params, true ) );
+				$listings = $this->otis->call( 'listings', $params, $this->logger );
 
 				if ( isset( $params['start_date']) && isset( $params['end_date'] ) ) {
 					// filter listings by modified date

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -579,7 +579,6 @@ class Otis_Importer {
 		$bulk = get_option( WP_OTIS_BULK_IMPORT_ACTIVE, false );
 
 		if (!$bulk) {
-			$this->logger->log("Running history import with arguments: ".print_r($assoc_args, true));
 			$transient_history = get_transient(WP_OTIS_BULK_IMPORT_TRANSIENT);
 
 			if ( empty( $transient_history ) ) {

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -424,6 +424,7 @@ class Otis_Importer {
 						}
         } else if ( ! empty( $listings['results'] ) ) {
 					// The filter returned results, so we can import them.
+					$this->logger->log("Processing " . count($listings['results']) . " relevant listings...");
 					$import_related_only = false;
 					if ( isset($assoc_args['related_only']) ) {
 						$import_related_only = $assoc_args['related_only'];

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -354,6 +354,7 @@ class Otis_Importer {
 						}
 				}
 
+				$this->logger->log('Calling OTIS listings w/ params', $params);
         $listings = $this->otis->call( 'listings', $params );
 
         if ( empty( $listings['results'] ) ) {

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -414,7 +414,6 @@ class Otis_Importer {
             }
 
             try {
-							$this->logger->log("Upserting post " . $post_id); 
 							$post_id = $this->_upsert_poi( $post_id, $result, $import_related_only );
             } catch ( Exception $exception ) {
 							$this->logger->log( $exception->getMessage(), $post_id, 'error' );

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -542,7 +542,7 @@ class Otis_Importer {
 						'related_only' => $assoc_args['related_only']
 					]
 				];
-				$bulk_history_params['params'] = wp_otis_make_modified_datetime_param($assoc_args, $bulk_history_params['params']);
+				$bulk_history_params['params'] = wp_otis_make_modified_date_param($assoc_args, $bulk_history_params['params']);
 				as_enqueue_async_action('wp_otis_async_bulk_history_import', $bulk_history_params);
 			} else {
 				// If retrieval is complete, get the data from the transient.
@@ -558,11 +558,11 @@ class Otis_Importer {
 						update_option(WP_OTIS_BULK_HISTORY_ACTIVE, true);
 						$assoc_args['bulk-history-page'] = 1;
 						$history_bulk = true;
-						$logger_date = wp_otis_get_logger_modified_datetime_string($assoc_args);
+						$logger_date = wp_otis_get_logger_modified_date_string($assoc_args);
 						$this->logger->log("OTIS bulk history import detected: " . $history_total . " updates. " . $logger_date);
 					}
 				} else {
-					$logger_date = wp_otis_get_logger_modified_datetime_string($assoc_args);
+					$logger_date = wp_otis_get_logger_modified_date_string($assoc_args);
 					$this->logger->log("OTIS nonbulk history import detected: " . $history_total . " updates. " . $logger_date);
 				}
 

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -446,13 +446,12 @@ class Otis_Importer {
 
 					foreach ( $listings['results'] as $result ) {
 						$uuid = $result['uuid'];
-						$this->logger->log("Processing POI with UUID: " . $uuid);
 						$poi_post = get_posts([
 							'post_type' => 'poi',
 							'post_status' => 'any',
 							'meta_key' => 'uuid',
 							'meta_value' => $uuid,
-							'posts_per_page' => - 1,
+							'posts_per_page' => 1,
 						]);
 						$post_id = 0;
 						if (count($poi_post) > 0) {

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -662,7 +662,7 @@ class Otis_Importer {
 								'related_only' => $assoc_args['related_only']
 							]
 						];
-						$bulk_history_params['params'] = wp_otis_make_modified_datetime_param($assoc_args, $bulk_history_params['params']);
+						$bulk_history_params['params'] = wp_otis_make_modified_date_param($assoc_args, $bulk_history_params['params']);
 						as_enqueue_async_action('wp_otis_async_bulk_history_import', $bulk_history_params);
 					} elseif ($assoc_args['bulk-history-page'] == $history_page_count) {
 						update_option(WP_OTIS_BULK_HISTORY_ACTIVE, false);

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -541,7 +541,6 @@ class Otis_Importer {
 					}
 				} else {
 					$this->logger->log("No POIs to import.");
-					return;
 				}
     }
 
@@ -683,7 +682,6 @@ class Otis_Importer {
 				if ($history_bulk) {
 					if ($assoc_args['bulk-history-page'] < $history_page_count) {
 						$assoc_args['bulk-history-page'] = $assoc_args['bulk-history-page'] + 1;
-						$this->logger->log('Enqueueing history import page ' . $assoc_args['bulk-history-page']);
 						$bulk_history_params = [
 							'params' => [
 								'all' => $assoc_args['all'],

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -354,8 +354,7 @@ class Otis_Importer {
 						}
 				}
 
-				$this->logger->log('Calling OTIS listings w/ params' . $params);
-        $listings = $this->otis->call( 'listings', $params );
+        $listings = $this->otis->call( 'listings', $params, $this->logger );
 
         if ( empty( $listings['results'] ) ) {
             return;

--- a/wp-otis.php
+++ b/wp-otis.php
@@ -134,7 +134,7 @@ add_action( 'wp_otis_async_bulk_history_import', function ( $params ) {
 		if ($params['page'] > 1) {
 			$logger->log( "Bulk OTIS history import continuing on page ".$params['page'].". (".wp_otis_get_logger_modified_date_string($params).")");
 		} else {
-			$logger->log( "Fetching history data..." );
+			$logger->log( "Fetching history..." );
 		}
 
 		try {

--- a/wp-otis.php
+++ b/wp-otis.php
@@ -407,6 +407,10 @@ function wp_otis_get_logger_modified_date_string( $args = [] ) {
 		} else {
 			return $args['modified_start'] . ' - ' . $args['modified_end'];
 		}
+	} else if ( isset( $args['start_date'] ) && isset( $args['end_date'] ) ) {
+		return $args['start_date'] . ' - ' . $args['end_date'];
+	} else if ( isset( $args['start_date'] ) ) {
+		return $args['start_date'];
 	} else {
 		return '';
 	}

--- a/wp-otis.php
+++ b/wp-otis.php
@@ -131,7 +131,11 @@ add_action( 'wp_otis_async_bulk_history_import', function ( $params ) {
 		$otis     = new Otis();
 		$logger   = new Otis_Logger_Simple();
 		$importer = new Otis_Importer( $otis, $logger );
-		$logger->log( "Bulk OTIS history import continuing on page ".$params['page'].". (".wp_otis_get_logger_modified_date_string($params).")");
+		if ($params['page'] > 1) {
+			$logger->log( "Bulk OTIS history import continuing on page ".$params['page'].". (".wp_otis_get_logger_modified_date_string($params).")");
+		} else {
+			$logger->log( "Fetching history data..." );
+		}
 
 		try {
 			$importer_params = [

--- a/wp-otis.php
+++ b/wp-otis.php
@@ -133,8 +133,6 @@ add_action( 'wp_otis_async_bulk_history_import', function ( $params ) {
 		$importer = new Otis_Importer( $otis, $logger );
 		if ($params['page'] > 1) {
 			$logger->log( "Bulk OTIS history import continuing on page ".$params['page'].". (".wp_otis_get_logger_modified_date_string($params).")");
-		} else {
-			$logger->log( "Fetching history..." );
 		}
 
 		try {


### PR DESCRIPTION
## Overview
This reworks logging, replaces the giant query that happens in upserting POIs, and adds a date range field to the dashboard and supporting server logic.

## Notes
This has been well tested and needs a look at the code to make sure it's sound and a check for things like forgotten console logs.

## Locations of Note
- Line 447 of Otis_Importer.php (for loop that replaces the while loop that's commented out below)
- Line 365 of Otis_Importer.php (new logic to look for modified date vs date range and new Otis date formatting)
- Line 61 of Otis_Dashboard.php (logic for modified_start and end params)