### PR TITLE
OTIS Deletes Sync Tool

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -26,6 +26,9 @@
 	width: 50%;
 	padding: 10px 10px 10px 0;
 }
+.otis-dashboard .otis-dashboard__setting.otis-dashboard__setting--full-width {
+	width: 100%;
+}
 .otis-dashboard .otis-dashboard__initial-import {
 	box-sizing: border-box;
 	padding: 10px 10px 10px 0;

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -118,6 +118,9 @@
 										<span v-if="bulkImportActive || bulkImportScheduled">Sync Running Please Wait...</span>
 										<span v-else>Sync Deleted POIs</span>
 									</button>
+									<button v-if="bulkImportActive" class="button button-primary" @click="stopBulkImporter">
+										Stop Deletes Sync
+									</button>
 								</div>
 							</div>
 						</div>

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -114,9 +114,13 @@
 							<div class="otis-dashboard__action">
 								<div class="otis-dashboard__action-button">
 									<label>This will fetch the list of deleted POIs, check them against the POIs still active in WordPress, and delete the POI post if relevant. <strong>This will delete POIs if they've been removed from OTIS.</strong></label>
-									<button class="button button-primary" @click="triggerSyncDeletes">Sync Deleted POIs</button>
+									<button class="button button-primary" :disabled="bulkImportActive" @click="triggerSyncDeletes">
+										<span v-if="bulkImportActive">Sync Running Please Wait...</span>
+										<span v-else>Sync Deleted POIs</span>
+									</button>
 								</div>
 							</div>
+						</div>
 					</div>
           <div v-if="!displayInitialImport" class="otis-dashboard__setting">
             <div class="postbox">

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -114,7 +114,7 @@
 							<div class="otis-dashboard__action">
 								<div class="otis-dashboard__action-button">
 									<label>This will fetch the list of deleted POIs and check them against the POIs still active in WordPress and return it for your review. <strong>This will not delete POIs</strong></label>
-									<button class="button button-primary" :disabled="!bulkImportActive" @click="fetchDeletedPois">Get List of Deleted POIs From Otis</button>
+									<button class="button button-primary" :disabled="!bulkImportActive" @click="triggerRetrieveDeletes">Get List of Deleted POIs From Otis</button>
 								</div>
 							</div>
 					</div>

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -114,7 +114,7 @@
 							<div class="otis-dashboard__action">
 								<div class="otis-dashboard__action-button">
 									<label>This will fetch the list of deleted POIs, check them against the POIs still active in WordPress, and delete the POI post if relevant. <strong>This will delete POIs if they've been removed from OTIS.</strong></label>
-									<button class="button button-primary" :disabled="bulkImportActive" @click="triggerSyncDeletes">
+									<button class="button button-primary" :disabled="importStarting || bulkImportActive" @click="triggerSyncDeletes">
 										<span v-if="bulkImportActive">Sync Running Please Wait...</span>
 										<span v-else>Sync Deleted POIs</span>
 									</button>

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -310,6 +310,7 @@
 					return;
 				}
 				await this.triggerAction("otis_sync_deleted_pois");
+				await this.otisStatus();
 				this.importStarting = false;
 			},
 		},

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -119,7 +119,7 @@
 										<span v-else>Sync Deleted POIs</span>
 									</button>
 									<button v-if="bulkImportActive" class="button button-primary" @click="stopBulkImporter">
-										Stop Deletes Sync
+										Stop Importer and Syncing
 									</button>
 								</div>
 							</div>

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -107,6 +107,17 @@
               </div>
             </div>
           </div>
+					<div v-if="!displayInitialImport" class="otis-dashboard__setting otis-dashboard__setting--full-width">
+						<div class="postbox">
+							<h2>Sync Deleted POIs</h2>
+							<p>This will sync all deleted POIs from the OTIS to the local database. This is useful if you find there are POIs that are stale/should have been deleted.</p>
+							<div class="otis-dashboard__action">
+								<div class="otis-dashboard__action-button">
+									<label>This will fetch the list of deleted POIs and check them against the POIs still active in WordPress and return it for your review. <strong>This will not delete POIs</strong></label>
+									<button class="button button-primary" :disabled="!bulkImportActive" @click="fetchDeletedPois">Get List of Deleted POIs From Otis</button>
+								</div>
+							</div>
+					</div>
           <div v-if="!displayInitialImport" class="otis-dashboard__setting">
             <div class="postbox">
               <div v-if="logLoading" class="otis-ellipsis"><div /><div /><div /><div /></div>
@@ -161,6 +172,7 @@
 			bulkImportScheduled: false,
 			bulkHistoryImportScheduled: false,
 			bulkHistoryImportActive: "",
+			deletesPulse: [],
 			poiCount: {},
 			importLog: [],
 			importStarting: false,
@@ -286,9 +298,23 @@
 				this.notifyImportStarted();
 				this.importStarting = false;
 			},
+			async triggerRetrieveDeletes() {
+				this.importStarting = true;
+				await this.triggerAction("otis_check_deletes");
+				this.importStarting = false;
+				setInterval(async () => {
+					await this.getDeletesPulse();
+				}, 10000);
+			},
+			async getDeletesPulse() {
+				const { data } = await this.triggerAction("otis_deleted_pois_pulse");
+				this.deletesPulse = data;
+				console.log(data);
+			}
 		},
 		async mounted() {
 			await this.otisStatus();
+			await this.
 		},
 	});
 })();

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -247,6 +247,9 @@
 				this.dateRange.from = formattedFromDate;
 				this.dateRange.to = formattedToDate;
 			},
+			async sleep(ms) {
+				return new Promise(resolve => setTimeout(resolve, ms));
+			},
 			async triggerAction(action, data = {}) {
 				const payload = this.makePayload({
 					action,
@@ -302,9 +305,8 @@
 				this.importStarting = true;
 				await this.triggerAction("otis_check_deletes");
 				this.importStarting = false;
-				setInterval(async () => {
-					await this.getDeletesPulse();
-				}, 10000);
+				await this.sleep(100000);
+				await this.getDeletesPulse();
 			},
 			async getDeletesPulse() {
 				const { data } = await this.triggerAction("otis_deleted_pois_pulse");
@@ -314,7 +316,7 @@
 		},
 		async mounted() {
 			await this.otisStatus();
-			await this.
+			await this.getDeletesPulse();
 		},
 	});
 })();

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -114,8 +114,8 @@
 							<div class="otis-dashboard__action">
 								<div class="otis-dashboard__action-button">
 									<label>This will fetch the list of deleted POIs, check them against the POIs still active in WordPress, and delete the POI post if relevant. <strong>This will delete POIs if they've been removed from OTIS.</strong></label>
-									<button class="button button-primary" :disabled="importStarting || bulkImportActive" @click="triggerSyncDeletes">
-										<span v-if="bulkImportActive">Sync Running Please Wait...</span>
+									<button class="button button-primary" :disabled="importStarting || bulkImportActive != '' || bulkImportScheduled" @click="triggerSyncDeletes">
+										<span v-if="bulkImportActive || bulkImportScheduled">Sync Running Please Wait...</span>
 										<span v-else>Sync Deleted POIs</span>
 									</button>
 								</div>
@@ -267,6 +267,7 @@
 				Object.keys(data).forEach((key) => {
 					this[key] = data[key];
 				});
+				console.log(data);
 				this.countsLoading = false;
 				await this.otisLogPreview();
 			},

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -114,7 +114,7 @@
 							<div class="otis-dashboard__action">
 								<div class="otis-dashboard__action-button">
 									<label>This will fetch the list of deleted POIs and check them against the POIs still active in WordPress and return it for your review. <strong>This will not delete POIs</strong></label>
-									<button class="button button-primary" :disabled="!bulkImportActive" @click="triggerRetrieveDeletes">Get List of Deleted POIs From Otis</button>
+									<button class="button button-primary" @click="triggerRetrieveDeletes">Get List of Deleted POIs From Otis</button>
 								</div>
 							</div>
 					</div>

--- a/src/Otis_Dashboard.php
+++ b/src/Otis_Dashboard.php
@@ -135,7 +135,10 @@ class Otis_Dashboard
 
   public function otis_status() {
     echo json_encode([
-      'bulkImportScheduled' => as_next_scheduled_action( 'wp_otis_dashboard_start_import' ) || as_next_scheduled_action('wp_otis_dashboard_start_async_import'),
+      'bulkImportScheduled' => 
+        as_next_scheduled_action( 'wp_otis_dashboard_start_import' ) ||
+        as_next_scheduled_action('wp_otis_dashboard_start_async_import') ||
+        as_next_scheduled_action( 'wp_otis_dashboard_start_async_delete_pois' ),
       'bulkHistoryImportScheduled' => as_next_scheduled_action('wp_otis_async_bulk_history_import'),
       'bulkImportActive' => get_option( WP_OTIS_BULK_IMPORT_ACTIVE, false ),
       'bulkHistoryImportActive' => get_option( WP_OTIS_BULK_HISTORY_ACTIVE, false ),

--- a/src/Otis_Dashboard.php
+++ b/src/Otis_Dashboard.php
@@ -159,11 +159,11 @@ class Otis_Dashboard
       wp_die();
     }
     $transient_deletes = get_transient( WP_OTIS_BULK_DELETE_TRANSIENT );
-    $delete_posts = [];
+    $transient_deletes['posts'] = [];
     foreach ($transient_deletes['deleted_poi_post_ids'] as $poi_post_id) {
-      $delete_posts[] = get_post($poi_post_id);
+      $transient_deletes['posts'][] = get_post($poi_post_id);
     }
-    echo wp_json_encode($delete_posts);
+    echo wp_json_encode($transient_deletes);
     wp_die();
   }
 

--- a/src/Otis_Dashboard.php
+++ b/src/Otis_Dashboard.php
@@ -137,8 +137,8 @@ class Otis_Dashboard
     echo json_encode([
       'bulkImportScheduled' => as_next_scheduled_action( 'wp_otis_dashboard_start_import' ) || as_next_scheduled_action('wp_otis_dashboard_start_async_import'),
       'bulkHistoryImportScheduled' => as_next_scheduled_action('wp_otis_async_bulk_history_import'),
-      'bulkImportActive' => get_option( WP_OTIS_BULK_IMPORT_ACTIVE ),
-      'bulkHistoryImportActive' => get_option( WP_OTIS_BULK_HISTORY_ACTIVE ),
+      'bulkImportActive' => get_option( WP_OTIS_BULK_IMPORT_ACTIVE, false ),
+      'bulkHistoryImportActive' => get_option( WP_OTIS_BULK_HISTORY_ACTIVE, false ),
       'lastImportDate' => get_option( WP_OTIS_LAST_IMPORT_DATE ),
       'poiCount' => $this->otis_poi_counts(),
     ]);

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -606,10 +606,12 @@ class Otis_Importer {
 			if ( isset( $deletes_page['next'] ) && $deletes_page['next'] ) {
 				$transient_deletes['next_page'] = strval( intval( $transient_deletes['next'] ) + 1 );
 				set_transient( WP_OTIS_BULK_DELETE_TRANSIENT, $transient_deletes, DAY_IN_SECONDS );
+				$this->logger->log( 'Set deletes transient moving to page: ' . $transient_deletes['next_page'] );
 				as_enqueue_async_action( 'wp_otis_async_fetch_deleted_pois' );
 			} else {
 				$transient_deletes['next_page'] = null;
 				set_transient( WP_OTIS_BULK_DELETE_TRANSIENT, $transient_deletes, DAY_IN_SECONDS );
+				$this->logger->log( 'Set deletes transient complete' );
 			}
 		} else {
 			$transient_deletes = [
@@ -617,6 +619,7 @@ class Otis_Importer {
 				'next_page'            => '2',
 			];
 			set_transient( WP_OTIS_BULK_DELETE_TRANSIENT, $transient_deletes, DAY_IN_SECONDS );
+			$this->logger->log( 'Set deletes transient moving to page: ' . $transient_deletes['next_page'] );
 			as_enqueue_async_action( 'wp_otis_async_fetch_deleted_pois' );
 		}
 	}

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -591,7 +591,7 @@ class Otis_Importer {
 			$params['page'] = $transient_deletes['next_page'];
 		}
 		// Get data from OTIS
-		$deletes_page = $this->otis->call( 'listings/history', $params );
+		$deletes_page = $this->otis->call( 'listings/history', $params, $this->logger );
 
 		foreach ( $deletes_page['results'] as $delete ) {
 			$deleted_uuid = $delete['uuid'];

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -580,6 +580,15 @@ class Otis_Importer {
 			'alldeletes' => 'True',
 		];
 		$page = isset( $assoc_args['deletes_page'] ) ? intval( $assoc_args['deletes_page'] ) : 1;
+
+		// Check if bulk flag is set. If it isn't and we're not on the first page then someone wants to stop the bulk import.
+		$bulk = get_option( WP_OTIS_BULK_IMPORT_ACTIVE, false );
+		if ( ! $bulk && $page > 1 ) {
+			$this->logger->log( 'Stopping delete sync according to Bulk Import flag' );
+			as_unschedule_all_actions( 'wp_otis_bulk_delete_pois' );
+			$this->logger->log( 'Deletes sync stopped.' );
+			return;
+		}
 		if ( $page ) {
 			$params['page'] = $page;
 		}

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -600,6 +600,10 @@ class Otis_Importer {
 				$deleted_poi_post_ids[] = $post_id;
 			}
 		}
+
+		if ( ! count($deletes_page['results']) ) {
+			$deletes_page['next'] = null;
+		}
 		$this->logger->log( 'Setting deletes transient with post IDs: ' . implode( ', ', $deleted_poi_post_ids ) );
 		// Set Transient w/ Updated Deleted POI Post IDs and next page value from OTIS if available. Enqueue next page retrieval via action scheduler.
 		if ( $transient_deletes ) {

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -591,7 +591,7 @@ class Otis_Importer {
 			$params['page'] = $transient_deletes['next_page'];
 		}
 		// Get data from OTIS
-		$deletes_page = $this->otis->call( 'history', $params );
+		$deletes_page = $this->otis->call( 'listings/history', $params );
 
 		foreach ( $deletes_page['results'] as $delete ) {
 			$deleted_uuid = $delete['uuid'];

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -600,6 +600,7 @@ class Otis_Importer {
 				$deleted_poi_post_ids[] = $post_id;
 			}
 		}
+		$this->logger->log( 'Setting deletes transient with post IDs: ' . implode( ', ', $deleted_poi_post_ids ) );
 		// Set Transient w/ Updated Deleted POI Post IDs and next page value from OTIS if available. Enqueue next page retrieval via action scheduler.
 		if ( $transient_deletes ) {
 			$transient_deletes['deleted_poi_post_ids'] = array_merge( $transient_deletes['deleted_poi_post_ids'], $deleted_poi_post_ids );

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -608,6 +608,7 @@ class Otis_Importer {
 		} else {
 			$this->logger->log( 'Processed deletes page 1, enqueuing async action for page: 2' );
 			as_enqueue_async_action( 'wp_otis_bulk_delete_pois', [ 'deletes_page' => 2 ] );
+			update_option( WP_OTIS_BULK_IMPORT_ACTIVE, true );
 		}
 	}
 

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -604,7 +604,7 @@ class Otis_Importer {
 		if ( $transient_deletes ) {
 			$transient_deletes['deleted_poi_post_ids'] = array_merge( $transient_deletes['deleted_poi_post_ids'], $deleted_poi_post_ids );
 			if ( isset( $deletes_page['next'] ) && $deletes_page['next'] ) {
-				$transient_deletes['next_page'] = strval( intval( $transient_deletes['next'] ) + 1 );
+				$transient_deletes['next_page'] = strval( intval( $transient_deletes['next_page'] ) + 1 );
 				set_transient( WP_OTIS_BULK_DELETE_TRANSIENT, $transient_deletes, DAY_IN_SECONDS );
 				$this->logger->log( 'Set deletes transient moving to page: ' . $transient_deletes['next_page'] );
 				as_enqueue_async_action( 'wp_otis_async_fetch_deleted_pois' );

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -604,7 +604,7 @@ class Otis_Importer {
 		if ( $transient_deletes ) {
 			$transient_deletes['deleted_poi_post_ids'] = array_merge( $transient_deletes['deleted_poi_post_ids'], $deleted_poi_post_ids );
 			if ( isset( $deletes_page['next'] ) && $deletes_page['next'] ) {
-				$transient_deletes['next_page'] = $deletes_page['next'];
+				$transient_deletes['next_page'] = strval( intval( $transient_deletes['next'] ) + 1 );
 				set_transient( WP_OTIS_BULK_DELETE_TRANSIENT, $transient_deletes, DAY_IN_SECONDS );
 				as_enqueue_async_action( 'wp_otis_async_fetch_deleted_pois' );
 			} else {

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -600,14 +600,16 @@ class Otis_Importer {
 			if ( isset( $deletes_page['next'] ) && $deletes_page['next'] ) {
 				$next_page = intval( $page ) + 1;
 				$this->logger->log( 'Processed deletes page: ' . $page . ', enqueuing async action for page: ' . $next_page );
-				as_enqueue_async_action( 'wp_otis_bulk_delete_pois', [ 'deletes_page' => $next_page ] );
+				as_enqueue_async_action( 'wp_otis_bulk_delete_pois', [ 'params' => [ 'deletes_page' => $next_page ] ] );
 			} else {
-				$this->logger->log( 'No next page, finished deletes. Removing bulk import flag' );
+				$this->logger->log( 'No next page, finished deletes. Cleaning up and removing bulk import flag' );
+				as_unschedule_action( 'wp_otis_bulk_delete_pois' );
 				update_option( WP_OTIS_BULK_IMPORT_ACTIVE, false );
+				$this->logger->log( 'Deletes sync finished.' );
 			}
 		} else {
 			$this->logger->log( 'Processed deletes page 1, enqueuing async action for page: 2' );
-			as_enqueue_async_action( 'wp_otis_bulk_delete_pois', [ 'deletes_page' => 2 ] );
+			as_enqueue_async_action( 'wp_otis_bulk_delete_pois', [ 'params' => [ 'deletes_page' => 2 ] ] );
 			update_option( WP_OTIS_BULK_IMPORT_ACTIVE, true );
 		}
 	}

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -606,7 +606,7 @@ class Otis_Importer {
 			if ( isset( $deletes_page['next'] ) && $deletes_page['next'] ) {
 				$transient_deletes['next_page'] = $deletes_page['next'];
 				set_transient( WP_OTIS_BULK_DELETE_TRANSIENT, $transient_deletes, DAY_IN_SECONDS );
-				as_enqueue_async_action( 'wp_otis_async_fetch_deleted_pois', [] );
+				as_enqueue_async_action( 'wp_otis_async_fetch_deleted_pois' );
 			} else {
 				$transient_deletes['next_page'] = null;
 				set_transient( WP_OTIS_BULK_DELETE_TRANSIENT, $transient_deletes, DAY_IN_SECONDS );
@@ -617,7 +617,7 @@ class Otis_Importer {
 				'next_page'            => '2',
 			];
 			set_transient( WP_OTIS_BULK_DELETE_TRANSIENT, $transient_deletes, DAY_IN_SECONDS );
-			as_enqueue_async_action( 'wp_otis_async_fetch_deleted_pois', [] );
+			as_enqueue_async_action( 'wp_otis_async_fetch_deleted_pois' );
 		}
 	}
 

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -586,11 +586,12 @@ class Otis_Importer {
 		// Get data from OTIS
 		$deletes_page = $this->otis->call( 'listings/history', $params, $this->logger );
 
+		$this->logger->log( 'Checking for relevant deletes but UUID...' );
 		foreach ( $deletes_page['results'] as $delete ) {
 			$deleted_uuid = $delete['uuid'];
 			$post_id      = wp_otis_get_post_id_for_uuid( $deleted_uuid );
 			if ( $post_id ) {
-				$this->logger->log( 'Deleting Post with ID ' . $post_id . ' and UUID ' . $deleted_uuid );
+				$this->logger->log( 'Deleting Post with ID ' . $post_id . ' and UUID ' . $deleted_uuid, $post_id );
 				wp_trash_post( $post_id );
 			}
 		}

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -606,7 +606,7 @@ class Otis_Importer {
 			if ( isset( $deletes_page['next'] ) && $deletes_page['next'] ) {
 				$transient_deletes['next_page'] = $deletes_page['next'];
 				set_transient( WP_OTIS_BULK_DELETE_TRANSIENT, $transient_deletes, DAY_IN_SECONDS );
-				as_enqueue_async_action( 'wp_otis_async_fetch_deleted_pois' );
+				as_enqueue_async_action( 'wp_otis_async_fetch_deleted_pois', [] );
 			} else {
 				$transient_deletes['next_page'] = null;
 				set_transient( WP_OTIS_BULK_DELETE_TRANSIENT, $transient_deletes, DAY_IN_SECONDS );
@@ -617,7 +617,7 @@ class Otis_Importer {
 				'next_page'            => '2',
 			];
 			set_transient( WP_OTIS_BULK_DELETE_TRANSIENT, $transient_deletes, DAY_IN_SECONDS );
-			as_enqueue_async_action( 'wp_otis_async_fetch_deleted_pois' );
+			as_enqueue_async_action( 'wp_otis_async_fetch_deleted_pois', [] );
 		}
 	}
 

--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -608,6 +608,7 @@ class Otis_Importer {
 				set_transient( WP_OTIS_BULK_DELETE_TRANSIENT, $transient_deletes, DAY_IN_SECONDS );
 				as_enqueue_async_action( 'wp_otis_async_fetch_deleted_pois' );
 			} else {
+				$transient_deletes['next_page'] = null;
 				set_transient( WP_OTIS_BULK_DELETE_TRANSIENT, $transient_deletes, DAY_IN_SECONDS );
 			}
 		} else {

--- a/wp-otis.php
+++ b/wp-otis.php
@@ -129,6 +129,7 @@ add_action( 'wp_otis_bulk_delete_pois', function( $params ) {
 	$importer = new Otis_Importer( $otis, $logger );
 
 	try {
+		$logger->log( 'Starting bulk delete page with params: ' . print_r( $params, true ) );
 		$importer->import('deleted-pois', $params);
 	} catch ( Exception $e ) {
 		$logger->log( $e->getMessage(), 0, 'error' );

--- a/wp-otis.php
+++ b/wp-otis.php
@@ -19,6 +19,7 @@ define( 'WP_OTIS_TOKEN', 'wp_otis_token' );
 define( 'WP_OTIS_LAST_IMPORT_DATE', 'wp_otis_last_import_date' );
 define( 'WP_OTIS_BULK_IMPORT_ACTIVE', 'wp_otis_bulk_import_active' );
 define( 'WP_OTIS_BULK_IMPORT_TRANSIENT', 'wp_otis_bulk_import_transient' );
+define( 'WP_OTIS_BULK_DELETE_TRANSIENT', 'wp_otis_bulk_delete_transient' );
 define( 'WP_OTIS_BULK_HISTORY_ACTIVE', 'wp_otis_bulk_history_active' );
 define( 'WP_OTIS_BULK_DISABLE_CACHE', 0 );
 
@@ -121,6 +122,30 @@ add_action( 'wp_otis_cron', function () {
     }
 
 } );
+
+add_action( 'wp_otis_async_fetch_deleted_pois', function( $params ) {
+	$otis     = new Otis();
+	$logger   = new Otis_Logger_Simple();
+	$importer = new Otis_Importer( $otis, $logger );
+
+	try {
+		$importer->import('deletes-list', $params);
+	} catch ( Exception $e ) {
+		$logger->log( $e->getMessage(), 0, 'error' );
+	}
+}, 10, 1 );
+
+add_action( 'wp_otis_async_delete_transient_pois', function( $params ) {
+	$otis     = new Otis();
+	$logger   = new Otis_Logger_Simple();
+	$importer = new Otis_Importer( $otis, $logger );
+
+	try {
+		$importer->import('deleted-pois', $params);
+	} catch ( Exception $e ) {
+		$logger->log( $e->getMessage(), 0, 'error' );
+	}
+}, 10, 1 );
 
 add_action( 'wp_otis_async_bulk_history_import', function ( $params ) {
 

--- a/wp-otis.php
+++ b/wp-otis.php
@@ -123,29 +123,29 @@ add_action( 'wp_otis_cron', function () {
 
 } );
 
-add_action( 'wp_otis_async_fetch_deleted_pois', function( $params ) {
+add_action( 'wp_otis_async_fetch_deleted_pois', function() {
 	$otis     = new Otis();
 	$logger   = new Otis_Logger_Simple();
 	$importer = new Otis_Importer( $otis, $logger );
 
 	try {
-		$importer->import('deletes-list', $params);
+		$importer->import('deletes-list', []);
 	} catch ( Exception $e ) {
 		$logger->log( $e->getMessage(), 0, 'error' );
 	}
-}, 10, 1 );
+}, 10, 0 );
 
-add_action( 'wp_otis_async_delete_transient_pois', function( $params ) {
+add_action( 'wp_otis_async_delete_transient_pois', function() {
 	$otis     = new Otis();
 	$logger   = new Otis_Logger_Simple();
 	$importer = new Otis_Importer( $otis, $logger );
 
 	try {
-		$importer->import('deleted-pois', $params);
+		$importer->import('deleted-pois', []);
 	} catch ( Exception $e ) {
 		$logger->log( $e->getMessage(), 0, 'error' );
 	}
-}, 10, 1 );
+}, 10, 0 );
 
 add_action( 'wp_otis_async_bulk_history_import', function ( $params ) {
 

--- a/wp-otis.php
+++ b/wp-otis.php
@@ -123,29 +123,17 @@ add_action( 'wp_otis_cron', function () {
 
 } );
 
-add_action( 'wp_otis_async_fetch_deleted_pois', function() {
+add_action( 'wp_otis_bulk_delete_pois', function( $params ) {
 	$otis     = new Otis();
 	$logger   = new Otis_Logger_Simple();
 	$importer = new Otis_Importer( $otis, $logger );
 
 	try {
-		$importer->import('deletes-list', []);
+		$importer->import('deleted-pois', $params);
 	} catch ( Exception $e ) {
 		$logger->log( $e->getMessage(), 0, 'error' );
 	}
-}, 10, 0 );
-
-add_action( 'wp_otis_async_delete_transient_pois', function() {
-	$otis     = new Otis();
-	$logger   = new Otis_Logger_Simple();
-	$importer = new Otis_Importer( $otis, $logger );
-
-	try {
-		$importer->import('deleted-pois', []);
-	} catch ( Exception $e ) {
-		$logger->log( $e->getMessage(), 0, 'error' );
-	}
-}, 10, 0 );
+}, 10, 1 );
 
 add_action( 'wp_otis_async_bulk_history_import', function ( $params ) {
 


### PR DESCRIPTION
## Overview
Adds UI to the otis dashboard that allows users to trigger a deletes only sync action. As well this adds the supporting actions and logic to the importer and wp-otis files.

## Dev
Significant changes were made to:
- src/Otis_Dashboard.php
- src/Otis_Importer.php
- wp-otis.php
- js/dashboard.js

As well as minor changes to
- css/dashboard.css