### PR TITLE
Last import date fix

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -194,7 +194,7 @@
 				const day = lastImportDate.getDate();
 				const year = lastImportDate.getFullYear();
 				const hours = lastImportDate.getHours();
-				const minutes = lastImportDate.getMinutes();
+				const minutes = lastImportDate.getMinutes() > 9 ? lastImportDate.getMinutes() : "0" + lastImportDate.getMinutes();
 				return `${month}/${day}/${year} @ ${hours}:${minutes}`;
 			},
 			importerStatus() {
@@ -275,7 +275,6 @@
 				Object.keys(data).forEach((key) => {
 					this[key] = data[key];
 				});
-				console.log(data);
 				this.countsLoading = false;
 				await this.otisLogPreview();
 			},

--- a/wp-otis.php
+++ b/wp-otis.php
@@ -111,11 +111,10 @@ add_action( 'wp_otis_cron', function () {
         $importer = new Otis_Importer( $otis, $logger );
 
         try {
+						update_option( WP_OTIS_LAST_IMPORT_DATE, $current_date );
             $importer->import( 'pois', [
               'modified' => $last_import_date,
             ] );
-            update_option( WP_OTIS_LAST_IMPORT_DATE, $current_date );
-
         } catch ( Exception $e ) {
             $logger->log( $e->getMessage(), 0, 'error' );
         }

--- a/wp-otis.php
+++ b/wp-otis.php
@@ -110,13 +110,14 @@ add_action( 'wp_otis_cron', function () {
         $logger   = new Otis_Logger_Simple();
         $importer = new Otis_Importer( $otis, $logger );
 
+				update_option( WP_OTIS_LAST_IMPORT_DATE, $current_date );
         try {
-						update_option( WP_OTIS_LAST_IMPORT_DATE, $current_date );
-            $importer->import( 'pois', [
-              'modified' => $last_import_date,
-            ] );
+					$importer->import( 'pois', [
+						'modified' => $last_import_date,
+					] );
         } catch ( Exception $e ) {
-            $logger->log( $e->getMessage(), 0, 'error' );
+					$logger->log( $e->getMessage(), 0, 'error' );
+					update_option( WP_OTIS_LAST_IMPORT_DATE, $last_import_date );
         }
     }
 


### PR DESCRIPTION
## Overview
The last import date option wasn't getting set causing repeated imports to run. This addresses the issue by setting the option ahead of the import with error handling.

## Files Addressed
- js/dashboard.js
- wp-otis.php