### PR TITLE
Related Only Global Fix

### DIFF
--- a/src/Otis_Importer.php
+++ b/src/Otis_Importer.php
@@ -741,9 +741,11 @@ class Otis_Importer {
 							'params' => [
 								'all' => $assoc_args['all'],
 								'bulk-history-page' => $assoc_args['bulk-history-page'],
-								'related_only' => $assoc_args['related_only']
 							]
 						];
+						if ( isset( $assoc_args['related_only'] ) && $assoc_args['related_only'] ) {
+							$bulk_history_params['params']['related_only'] = $assoc_args['related_only'];
+						}
 						$bulk_history_params['params'] = wp_otis_make_modified_date_param($assoc_args, $bulk_history_params['params']);
 						as_enqueue_async_action('wp_otis_async_bulk_history_import', $bulk_history_params);
 					} elseif ($assoc_args['bulk-history-page'] == $history_page_count) {

--- a/wp-otis.php
+++ b/wp-otis.php
@@ -155,9 +155,11 @@ add_action( 'wp_otis_async_bulk_history_import', function ( $params ) {
 			$importer_params = [
 				'bulk-history-page' => $params['bulk-history-page'],
 				'history-page' => $params['history-page'],
-				'related_only' => isset($params['related_only']),
 				'all' => $params['all'],
 			];
+			if ( isset( $params['related_only'] ) && $params['related_only'] == 'true' || $params['related_only'] == true ) {
+				$importer_params['related_only'] = true;
+			}
 			$importer_params = wp_otis_make_modified_date_param($params, $importer_params);
 			$importer->import( 'history-only', $importer_params );
 		} catch ( Exception $e ) {
@@ -173,7 +175,6 @@ add_action( 'wp_otis_async_bulk_import', function( $params ) {
 	$all = $params['all'];
 	$page = $params['page'];
 	$page_size = $params['page_size'];
-	$related_only = isset($params['related_only']);
 
 	$otis     = new Otis();
 	$logger   = new Otis_Logger_Simple();
@@ -184,9 +185,11 @@ add_action( 'wp_otis_async_bulk_import', function( $params ) {
 		$importer_params = [
 			'page' => $page,
 			'page_size' => $page_size,
-			'related_only' => $related_only,
 			'all' => $all,
 		];
+		if ( isset( $params['related_only'] ) && $params['related_only'] == 'true' || $params['related_only'] == true ) {
+			$importer_params['related_only'] = true;
+		}
 		$importer_params = wp_otis_make_modified_date_param($params, $importer_params);
 		$importer->import( 'pois-only', $importer_params );
 	} catch ( Exception $e ) {


### PR DESCRIPTION
Refactors all active instances of related only flag to check both if they're set and if they're truthy.